### PR TITLE
Fix ice disconnect

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Send all endpoints metadata on ready notification [#14](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/14)
 * Rename `encoding` to `variant` when refering to simulcast layers [#15](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/15)
 * Use :protobuf as serializer in tests [#30](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/30)
+* Remove PeerConnection Supervisor [#32](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/32)  
 
 ## 0.23.0
 * Add RTCP sender reports [#393](https://github.com/fishjam-dev/membrane_rtc_engine/pull/393)

--- a/engine/lib/membrane_rtc_engine_app.ex
+++ b/engine/lib/membrane_rtc_engine_app.ex
@@ -5,8 +5,7 @@ defmodule Membrane.RTC.Engine.App do
   @impl true
   def start(_start_type, _start_args) do
     children = [
-      {Registry, keys: :duplicate, name: Membrane.RTC.Engine.get_registry_name()},
-      {Registry, keys: :unique, name: Membrane.RTC.Engine.Registry.PeerConnection}
+      {Registry, keys: :duplicate, name: Membrane.RTC.Engine.get_registry_name()}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/ex_webrtc/CHANGELOG.md
+++ b/ex_webrtc/CHANGELOG.md
@@ -21,3 +21,4 @@
 * Remove most of the metrics [#29](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/29)
 * Fix no bitrate for audio track; Fix examples [#30](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/30)
 * Fix webrtc metrics [#31](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/31)
+* Handle the same track added twice [#32](https://github.com/fishjam-cloud/membrane_rtc_engine/pull/32)

--- a/ex_webrtc/lib/ex_webrtc/peer_connection_handler.ex
+++ b/ex_webrtc/lib/ex_webrtc/peer_connection_handler.ex
@@ -264,6 +264,13 @@ defmodule Membrane.RTC.Engine.Endpoint.ExWebRTC.PeerConnectionHandler do
     {[], %{state | prev_transport_stats: transport_stats}}
   end
 
+  @impl true
+  def handle_terminate_request(_ctx, state) do
+    PeerConnection.close(state.pc)
+
+    {[terminate: :normal], state}
+  end
+
   defp handle_webrtc_msg({:ice_candidate, candidate}, _ctx, state) do
     msg = {:candidate, candidate}
     {[notify_parent: msg], state}


### PR DESCRIPTION
# Closes FCE-1156

This PR removes the PeerConnection Supervisor, which allows for a silent restart of the PeerConnection that causes engine crashes. Currently, the PeerConnection process is linked with the PeerConnectionHandler, so if one crashes, both will stop. 